### PR TITLE
(Revisao t5.1)delete image

### DIFF
--- a/editar-anuncio.php
+++ b/editar-anuncio.php
@@ -89,7 +89,7 @@ if(isset($_GET['id']) && !empty($_GET['id'])) {
 					<?php foreach($info['fotos'] as $foto): ?>
 					<div class="foto_item">
 						<img src="assets/images/anuncios/<?php echo $foto['url']; ?>" class="img-thumbnail" border="0" /><br/>
-						<a href="" class="btn btn-default">Excluir Imagem</a>
+						<a href="excluir-foto.php?id=<?php echo $foto['id']; ?>" class="btn btn-default">Excluir Imagem</a>
 					</div>
 					<?php endforeach; ?>
 				</div>


### PR DESCRIPTION
Erro encontrado durante o teste de excluir imagem em editar anuncio. O erro mostra falta de pagina após solicitar excluir imagem. Causa: Falta a t5.2 [back] de editar anuncio. Tarefa 5.1 funcionando corretamente e sem erros de sintaxe que afetem o funcionamento do código.